### PR TITLE
Fix Multiprocessing on Windows

### DIFF
--- a/vsp.py
+++ b/vsp.py
@@ -98,14 +98,11 @@ Subalgebra 1: {set_to_str(self.subalgebra1)}
 Subalgebra 2: {set_to_str(self.subalgebra2)}
 """
 
-def has_vsp(model: Model, interpretation: Dict[Operation, ModelFunction]) -> VSP_Result:
+def has_vsp(model: Model, impfunction: ModelFunction, mconjunction: Optional[ModelFunction] = None, mdisjunction: Optional[ModelFunction] = None) -> VSP_Result:
     """
     Checks whether a model has the variable
     sharing property.
     """
-    impfunction = interpretation[Implication]
-    mconjunction = interpretation.get(Conjunction)
-    mdisjunction = interpretation.get(Disjunction)
     top = find_top(model.carrier_set, mconjunction, mdisjunction)
     bottom = find_bottom(model.carrier_set, mconjunction, mdisjunction)
 


### PR DESCRIPTION
Windows rely on a different form of multiprocessing called "spawn" which does not share memory with the parent process. This meant that the logical operators had different memory addresses within each child process affecting the indexing of the interpretation.

This PR fixes this by not relying on an interpretation dictionary but instead passing the model functions directly to each child process.