### PR TITLE
(#42) Iterate over designated values instead of carrier set for VSP check

### DIFF
--- a/vsp.py
+++ b/vsp.py
@@ -47,7 +47,7 @@ def has_vsp(model: Model, impfunction: ModelFunction,
     # x -> y does not take a designiated value
     I: List[Tuple[ModelValue, ModelValue]] = []
 
-    for (x, y) in product(model.carrier_set, model.carrier_set):
+    for (x, y) in product(model.designated_values, model.designated_values):
         if impfunction(x, y) not in model.designated_values:
             I.append((x, y))
 


### PR DESCRIPTION
As discussed in Issue #42, we can reduce the number of subalgebra candidates that we consider by making use of the fact that $C \rightarrow C$ is always designated and hence a designated value will always exist within a subalgebra.

This is beneficial since the set of designated values is a subset of the overall carrier set, which will give us less things to check.